### PR TITLE
Initialize the project architecture

### DIFF
--- a/src/main/kotlin/dev/bingo/ticket/api/application/README.md
+++ b/src/main/kotlin/dev/bingo/ticket/api/application/README.md
@@ -1,0 +1,7 @@
+# Application Layer
+The application layer, responsible for defining use case interfaces and their implementations. 
+It serves as the core of the application logic, independent of infrastructure concerns.
+- Contains input ports (interfaces) that define use cases, and output (interfaces).
+- Contains use case implementations that fulfill these interfaces.
+- Application use cases can be invoked by any input mechanism (REST, gRPC, CLI, etc.).
+- Submodules representing bounded contexts or domains.

--- a/src/main/kotlin/dev/bingo/ticket/api/application/port/README.md
+++ b/src/main/kotlin/dev/bingo/ticket/api/application/port/README.md
@@ -1,0 +1,2 @@
+# Application's ports (input / output)
+- Defines the contracts (ports) for both input and output interactions. These interfaces abstract the application’s business logic and how it interacts with external systems.

--- a/src/main/kotlin/dev/bingo/ticket/api/application/port/input/README.md
+++ b/src/main/kotlin/dev/bingo/ticket/api/application/port/input/README.md
@@ -1,0 +1,2 @@
+# Input Ports
+- Defines the contracts (ports) for both input and output interactions. These interfaces abstract the application’s business logic and how it interacts with external systems.

--- a/src/main/kotlin/dev/bingo/ticket/api/application/port/input/usecase/README.md
+++ b/src/main/kotlin/dev/bingo/ticket/api/application/port/input/usecase/README.md
@@ -1,0 +1,4 @@
+# Use Case Interface Inputs
+- These are part of the application.port.input.usecase.
+- They define what operations the application exposes to its input adapters (e.g., REST controllers, CLI, etc.).
+- They are contracts that input adapters call but do not implement.

--- a/src/main/kotlin/dev/bingo/ticket/api/application/port/output/README.md
+++ b/src/main/kotlin/dev/bingo/ticket/api/application/port/output/README.md
@@ -1,0 +1,2 @@
+# Input Ports
+- Contains interfaces for the external systems the application depends on. These represent the output ports that infrastructure adapters implement.

--- a/src/main/kotlin/dev/bingo/ticket/api/application/usecase/README.md
+++ b/src/main/kotlin/dev/bingo/ticket/api/application/usecase/README.md
@@ -1,0 +1,8 @@
+# Use Case Module
+- Contains the concrete implementations of the use case interfaces from port.input.usecase.
+- These implementations handle the coordination of domain logic, error mapping, and any application-specific workflows.
+- Use Case Implementations:
+  - These go in the application.usecase (or application.service) layer.
+  - They implement the contracts defined in port.input.usecase.
+  - They coordinate business logic by invoking domain services, orchestrating workflows, handling errors, etc.
+  - If needed, they can use @Transactional to handle persistence boundaries.

--- a/src/main/kotlin/dev/bingo/ticket/api/domain/README.md
+++ b/src/main/kotlin/dev/bingo/ticket/api/domain/README.md
@@ -1,0 +1,4 @@
+# Application Layer
+Represents the core domain model and business logic. 
+This layer is entirely independent of the infrastructure and application layers.
+- Submodules representing bounded contexts or domains.

--- a/src/main/kotlin/dev/bingo/ticket/api/infrastructure/README.md
+++ b/src/main/kotlin/dev/bingo/ticket/api/infrastructure/README.md
@@ -1,0 +1,5 @@
+# Infrastructure Layer
+Contains all infrastructure-related code, such as input and output adapters, configuration, 
+and integrations with external systems.
+•	Implements the input adapters (e.g., REST controllers, gRPC services).
+•	These input adapters call the application’s use case interfaces defined in application.port.input.

--- a/src/main/kotlin/dev/bingo/ticket/api/infrastructure/adapter/README.md
+++ b/src/main/kotlin/dev/bingo/ticket/api/infrastructure/adapter/README.md
@@ -1,0 +1,4 @@
+# Infrastructure Layer
+Implements the application’s ports and adapts them to specific technologies.
+- Input: Contains concrete implementations of the input adapters.
+- Output: Implements output adapters for interacting with external systems like databases or messaging systems.

--- a/src/main/kotlin/dev/bingo/ticket/api/infrastructure/config/README.md
+++ b/src/main/kotlin/dev/bingo/ticket/api/infrastructure/config/README.md
@@ -1,0 +1,2 @@
+# Infrastructure Configuration
+Contains Spring or other configuration files (e.g., beans, security, datasource configurations).


### PR DESCRIPTION
The project architecture is initialized to follow the Hexagonal architecture.

- Hexagonal architecture: Clear separation of the domain business logic (core) with the incoming (input) and external calls (output) of the application, making the domain not tightly coupled and framework-agnostic. More details in their respective README.md