### PR TITLE
Add Ticket domain models

### DIFF
--- a/src/main/kotlin/dev/bingo/ticket/api/domain/ticket/model/Ticket.kt
+++ b/src/main/kotlin/dev/bingo/ticket/api/domain/ticket/model/Ticket.kt
@@ -1,0 +1,5 @@
+package dev.bingo.ticket.api.domain.ticket.model
+
+data class Ticket(
+    val rows: List<TicketRow>
+)

--- a/src/main/kotlin/dev/bingo/ticket/api/domain/ticket/model/TicketRow.kt
+++ b/src/main/kotlin/dev/bingo/ticket/api/domain/ticket/model/TicketRow.kt
@@ -1,0 +1,10 @@
+package dev.bingo.ticket.api.domain.ticket.model
+
+data class TicketRow(
+    val cells: List<TicketRowCell>
+)
+
+sealed class TicketRowCell {
+    data class NumberRowCell(val number: Int) : TicketRowCell()
+    object BlankRowCell : TicketRowCell()
+}


### PR DESCRIPTION
Adds the ticket domain related models. The business logic validations will exist in the strip generator services and not in the domain models.