### PR TITLE
Add column random value generator service and unit tests

### DIFF
--- a/src/main/kotlin/dev/bingo/ticket/api/domain/ticket/service/ColumnRandomValueGeneratorService.kt
+++ b/src/main/kotlin/dev/bingo/ticket/api/domain/ticket/service/ColumnRandomValueGeneratorService.kt
@@ -1,0 +1,52 @@
+package dev.bingo.ticket.api.domain.ticket.service
+
+import dev.bingo.ticket.api.domain.ticket.model.TicketColumnEnum
+import dev.bingo.ticket.api.domain.ticket.model.TicketColumn
+import dev.bingo.ticket.api.domain.ticket.model.TicketColumns
+import org.springframework.stereotype.Service
+
+@Service
+class ColumnRandomValueGeneratorService {
+
+    companion object {
+        /**
+         * The minimum and maximum number of values a column can have.
+         */
+        const val MIN_VALUES_PER_COLUMN = 1
+        const val MAX_VALUES_PER_COLUMN = 3
+    }
+
+    fun generateColumnValues(): TicketColumns {
+        /**
+         * Generates a `TicketColumns` object containing Bingo ticket columns with randomized values.
+         *
+         * The method creates a collection of ticket columns, where each column is associated with
+         * a predefined range of numbers (as defined in `TicketColumnEnum`). For each column,
+         * between 1 and 3 random numbers are selected from its respective range. These numbers are
+         * encapsulated within a `TicketColumn` object, and all columns are returned as part of a
+         * `TicketColumns` instance.
+         *
+         * @return a `TicketColumns` object that represents a complete set of columns for a Bingo ticket.
+         *
+         * Example:
+         * If the predefined ranges are:
+         * - Column 1: 1–9
+         * - Column 2: 10–19
+         * - ...
+         *
+         * This method may generate a result like:
+         * - Column 1: [3, 7] (2 numbers randomly selected from range 1–9)
+         * - Column 2: [12] (1 number randomly selected from range 10–19)
+         * - ...
+         *
+         * Each column contains up to 3 numbers, randomly chosen from its range.
+         */
+        val columns = TicketColumnEnum.allRanges().map { valuesRange ->
+            TicketColumn(
+                valuesRange.shuffled().take((MIN_VALUES_PER_COLUMN..MAX_VALUES_PER_COLUMN).random())
+            )
+        }
+
+        return TicketColumns(columns)
+    }
+}

--- a/src/test/groovy/dev/bingo/ticket/api/domain/ticket/service/ColumnRandomValueGeneratorServiceSpec.groovy
+++ b/src/test/groovy/dev/bingo/ticket/api/domain/ticket/service/ColumnRandomValueGeneratorServiceSpec.groovy
@@ -1,0 +1,43 @@
+package dev.bingo.ticket.api.domain.ticket.service
+
+import dev.bingo.ticket.api.domain.ticket.model.TicketColumnEnum
+import spock.lang.Specification
+import spock.lang.Subject
+
+class ColumnRandomValueGeneratorServiceSpec extends Specification {
+
+    @Subject
+    def columnRandomValueGeneratorService = new ColumnRandomValueGeneratorService()
+
+    def "when generateColumnValues is called then it should return TicketColumns with valid random numbers in each column"() {
+        given: "A set to track all seen numbers across all columns"
+            def seenNumbers = [] as Set
+            def allNumbers = TicketColumnEnum.allValues()
+            def maxTries = 1_000
+            def tryCount = 0
+
+        and: "Expected numbers range per column"
+            def columnRanges = TicketColumnEnum.allRanges()
+
+        when: "The generate method is called"
+            while (seenNumbers.size() < allNumbers.size() && tryCount < maxTries) {
+                def ticketColumns = columnRandomValueGeneratorService.generateColumnValues()
+                tryCount++
+
+                // Add generated numbers to the set of seen numbers
+                ticketColumns.columns.eachWithIndex { column, columnIndex ->
+                    // Validate each number is within the correct range for the column
+                    column.numbers.each { number ->
+                        assert columnRanges[columnIndex].contains(number) : "Number $number in column ${columnIndex + 1} is out of range"
+                        seenNumbers.add(number)
+                    }
+                }
+            }
+
+        then: "All possible values from each range are eventually seen or max tries are reached"
+            assert seenNumbers.size() == allNumbers.size()
+
+        and: "The number of tries to generate all possible numbers should not exceed the max limit"
+            assert tryCount < maxTries
+    }
+}


### PR DESCRIPTION
Adds a service responsible for generating a Bingo ticket's  columns with randomized values based on the game's rules.
More specifically, this service generates for each column, up to 3 numbers, randomly chosen from its range.

Example:
- Column 1: [3, 7] (2 numbers randomly selected from range 1–9)
- Column 2: [12] (1 number randomly selected from range 10–19)
