### PR TITLE
Add stress tests for 1, 1k, 10k and 100k strips generation

### DIFF
--- a/src/test/groovy/dev/bingo/ticket/api/stress/StressTestSpecification.groovy
+++ b/src/test/groovy/dev/bingo/ticket/api/stress/StressTestSpecification.groovy
@@ -1,0 +1,26 @@
+package dev.bingo.ticket.api.stress
+
+import spock.lang.Specification
+import spock.lang.Stepwise
+import java.util.concurrent.TimeUnit
+
+/**
+ * Base class for stress tests to handle timing logic.
+ */
+@Stepwise
+abstract class StressTestSpecification extends Specification {
+
+    long startTime
+    long endTime
+
+    def setup() {
+        startTime = System.nanoTime()
+    }
+
+    def cleanup() {
+        endTime = System.nanoTime()
+        long duration = TimeUnit.NANOSECONDS.toMillis(endTime - startTime)
+
+        println "Execution time for '${getSpecificationContext().currentIteration.name}': ${duration} ms"
+    }
+}

--- a/src/test/groovy/dev/bingo/ticket/api/stress/strip/StripGeneratorStressSpec.groovy
+++ b/src/test/groovy/dev/bingo/ticket/api/stress/strip/StripGeneratorStressSpec.groovy
@@ -1,0 +1,84 @@
+package dev.bingo.ticket.api.stress.strip
+
+import dev.bingo.ticket.api.BingoTicketGeneratorApplication
+import dev.bingo.ticket.api.domain.strip.service.StripGeneratorService
+import dev.bingo.ticket.api.domain.ticket.service.ColumnRandomValueGeneratorService
+import dev.bingo.ticket.api.domain.ticket.service.TicketGeneratorService
+import dev.bingo.ticket.api.domain.validation.validator.TicketColumnsValidator
+import dev.bingo.ticket.api.stress.StressTestSpecification
+import org.springframework.boot.test.context.SpringBootTest
+import spock.lang.Subject
+import spock.lang.Timeout
+
+import java.util.concurrent.TimeUnit
+
+@SpringBootTest(classes = BingoTicketGeneratorApplication.class)
+class StripGeneratorStressSpec extends StressTestSpecification {
+
+    def columnRandomValueGeneratorService = new ColumnRandomValueGeneratorService()
+    def ticketColumnsValidator = new TicketColumnsValidator()
+    def ticketGeneratorService = new TicketGeneratorService(columnRandomValueGeneratorService, ticketColumnsValidator)
+
+    @Subject
+    def stripGeneratorService = new StripGeneratorService(ticketGeneratorService)
+
+    @Timeout(value = 600, unit = TimeUnit.MILLISECONDS)
+    def "should generate 1k strips without error under 2 seconds"() {
+        given: "A target number of strips to generate"
+            def numberOfStrips = 1000
+            def generatedStrips = []
+
+        when: "The StripGeneratorService generates strips"
+            (1..numberOfStrips).each {
+                def strip = stripGeneratorService.generateStrip()
+                generatedStrips.add(strip)
+            }
+
+        then: "No exception occurs during generation"
+            generatedStrips.size() == numberOfStrips
+            println "Successfully generated $numberOfStrips strips!"
+    }
+
+    @Timeout(value = 1600, unit = TimeUnit.MILLISECONDS)
+    def "should generate 10k strips without error under 3 seconds"() {
+        given: "A target number of strips to generate"
+            def numberOfStrips = 10000
+            def generatedStrips = []
+
+        when: "The StripGeneratorService generates strips"
+            (1..numberOfStrips).each {
+                def strip = stripGeneratorService.generateStrip()
+                generatedStrips.add(strip)
+            }
+
+        then: "No exception occurs during generation"
+            generatedStrips.size() == numberOfStrips
+            println "Successfully generated $numberOfStrips strips!"
+    }
+
+    @Timeout(value = 8, unit = TimeUnit.SECONDS)
+    def "should generate 100k strips without error under 5 seconds"() {
+        given: "A target number of strips to generate"
+            def numberOfStrips = 100000
+            def generatedStrips = []
+
+        when: "The StripGeneratorService generates strips"
+            (1..numberOfStrips).each {
+                def strip = stripGeneratorService.generateStrip()
+                generatedStrips.add(strip)
+            }
+
+        then: "No exception occurs during generation"
+            generatedStrips.size() == numberOfStrips
+            println "Successfully generated $numberOfStrips strips!"
+    }
+
+    @Timeout(value = 15, unit = TimeUnit.MILLISECONDS)
+    def "should generate 1 strip without error"() {
+        when: "The StripGeneratorService generates strip"
+            stripGeneratorService.generateStrip()
+
+        then: "No exception occurs during generation"
+            println "Successfully generated 1 strip"
+    }
+}


### PR DESCRIPTION
Add stress tests for strip generation for:
- 1 strip (under 15 ms)                  | average real execution: **5-7 ms**
- 1k strips (under 600 ms)           | average real execution:  **400-460 ms**
- 10k strips (under 1.6 seconds)  | average real execution:  **700-800 ms**
- 100k strips (under 8 seconds)  | average real execution:  **5-7 seconds**

Note1: The average real execution times are based on my local machine executions.
The times used for the spec timeouts is above the real executions to give some space to different machines.

Note2: The reason why I am not using parameterized test for the multiple number of strips under test is due to the @Timeout annotation usage. I find more important to fail the test when something breaks the efficiency of the strips generation than showcase the parameterization of tests.

Note3: StressTestSpecification is used to showcase common spec interface for a context of tests, in this case the stress tests, where the execution time of each test in such spec implementor is counted and printed.